### PR TITLE
Change the integer limits constants to make the framework compile in macOS

### DIFF
--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -44,7 +44,7 @@ typedef std::set<id_type> set_id_t;
 typedef std::set<value_t> set_value_t;
 typedef std::map<std::string,size_t> map_str_idx_t;
 
-#define MaxValue LONG_LONG_MAX
-#define MaxUValue ULONG_LONG_MAX
+#define MaxValue LLONG_MAX
+#define MaxUValue ULLONG_MAX
 
 #endif


### PR DESCRIPTION
The constants `LONG_LONG_MAX` and `ULONG_LONG_MAX` seem to be exclusive to `gcc`. The standard equivalents seem to be `LLONG_MAX` and `ULLONG_MAX`, as specified in https://en.cppreference.com/w/cpp/types/climits.