### PR TITLE
Change `high_resolution_clock` with `system_clock` to allow compilation in macOS

### DIFF
--- a/src/utils/bfgp_utils.h
+++ b/src/utils/bfgp_utils.h
@@ -24,7 +24,7 @@ namespace utils{
 
     ///******* CHRONO METHODS *********
     std::chrono::time_point<std::chrono::system_clock> get_time(){
-        return std::chrono::high_resolution_clock::now();
+        return std::chrono::system_clock::now();
     }
 
     /// Precision up to 3 digits


### PR DESCRIPTION
The reason behind is that `std::chrono::high_resolution_clock` is an alias of [`std::chrono::system_clock`](https://en.cppreference.com/w/cpp/chrono/system_clock) or [`std::chrono::steady_clock`](https://en.cppreference.com/w/cpp/chrono/steady_clock), or a third, independent clock (see https://en.cppreference.com/w/cpp/chrono/high_resolution_clock).

In my macOS laptop, it seems that `high_resolution_clock` is an alias of `steady_clock` instead of `system_clock`. Therefore, the conversion from `high_resolution_clock` to `system_clock` is not allowed.

One alternative to the one proposed in the PR might be to change `get_time()` as follows:

```c++
    std::chrono::time_point<std::chrono::high_resolution_clock> get_time(){
        return std::chrono::high_resolution_clock::now();
    }
```

But this would imply multiple changes in other source files, and I don't know which one is the preferred approach.